### PR TITLE
test: align test implementation with README.md

### DIFF
--- a/datalad_remake/commands/tests/create_datasets.py
+++ b/datalad_remake/commands/tests/create_datasets.py
@@ -14,7 +14,7 @@ def update_config_for_remake(dataset: Dataset):
         action='set',
         scope='local',
         recursive=True,
-        spec=[('annex.security.allow-unverified-downloads', 'ACKTHPPT')],
+        spec=[('remote.remake.annex-security-allow-unverified-downloads', 'ACKTHPPT')],
         result_renderer='disabled',
     )
 
@@ -35,6 +35,7 @@ def add_remake_remote(dataset: Dataset, signing_key: str | None = None):
         ],
         capture_output=True,
     )
+    update_config_for_remake(dataset)
 
 
 def create_ds_hierarchy(
@@ -74,7 +75,6 @@ def create_ds_hierarchy(
         dataset[2].save(result_renderer='disabled')
 
     root_dataset.get(recursive=True, result_renderer='disabled')
-    update_config_for_remake(root_dataset)
 
     # Add datalad-remake remotes to the root dataset and all subdatasets
     add_remake_remote(root_dataset, signing_key)

--- a/datalad_remake/commands/tests/test_make.py
+++ b/datalad_remake/commands/tests/test_make.py
@@ -29,7 +29,7 @@ def test_duplicated_computation(tmp_path):
 
 
 @skip_if_on_windows
-def test_speculative_computation(tmp_path, datalad_cfg):
+def test_speculative_computation(tmp_path):
     root_dataset = create_simple_computation_dataset(tmp_path, 'ds1', 0, test_method)
 
     root_dataset.make(
@@ -38,12 +38,6 @@ def test_speculative_computation(tmp_path, datalad_cfg):
         output=['spec.txt'],
         prospective_execution=True,
         result_renderer='disabled',
-    )
-
-    # set annex security related variables to allow datalad-remake-URLs
-    # in speculative make commands
-    datalad_cfg.set(
-        'annex.security.allow-unverified-downloads', 'ACKTHPPT', scope='global'
     )
 
     # Perform the speculative computation


### PR DESCRIPTION
This commit changes the test code to use the config key `remote.<remote name>.annex-security-allow-unverified-downloads` for prospective computation, as described in `README.md`. In this case `<remote name>` is `remake`.