### PR TITLE
fix: remove modified-detection from provision command

### DIFF
--- a/datalad_remake/commands/make_cmd.py
+++ b/datalad_remake/commands/make_cmd.py
@@ -104,9 +104,7 @@ class Make(ValidatedInterface):
             'in $DATASET/.datalad/remake/methods)',
         ),
         'label': Parameter(
-            args=(
-                '--label',
-            ),
+            args=('--label',),
             doc='Label of the computation. This is a user defined name that '
             'is used to identify and prioritize computations, if more than one '
             'computation is registered for a file. If no label is provided, '

--- a/datalad_remake/commands/make_cmd.py
+++ b/datalad_remake/commands/make_cmd.py
@@ -105,7 +105,6 @@ class Make(ValidatedInterface):
         ),
         'label': Parameter(
             args=(
-                '-l',
                 '--label',
             ),
             doc='Label of the computation. This is a user defined name that '

--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -210,20 +210,6 @@ def provide(
         + ([source_branch] if source_branch else [])
     )
     call_git_lines(args, cwd=dataset.pathobj)
-
-    is_dirty = False
-    for element in get_dirty_elements(dataset):
-        is_dirty = True
-        yield get_status_dict(
-            action='provision',
-            path=element['path'],
-            status='error',
-            state=element['state'],
-            message=f'cannot provision {element["state"]} input: {element["path"]!r} from dataset {dataset}',
-        )
-    if is_dirty:
-        return
-
     worktree_dataset = Dataset(worktree_dir)
 
     # Get all input files in the worktree

--- a/datalad_remake/commands/tests/test_provision.py
+++ b/datalad_remake/commands/tests/test_provision.py
@@ -130,36 +130,6 @@ def test_provision_context(tmp_path):
     assert not worktree.exists()
 
 
-def test_unclean_dataset(tmp_path):
-    dataset = Dataset(tmp_path / 'ds1')
-    dataset.create(cfg_proc='text2git', result_renderer='disabled')
-    (dataset.pathobj / 'a.txt').write_text('content')
-    dataset.save()
-    (dataset.pathobj / 'a.txt').write_text('changed content')
-    (dataset.pathobj / 'b.txt').write_text('untracked content')
-
-    # Check that provision of unclean input results in errors
-    input_pattern = ['a.txt', 'b.txt']
-    results = dataset.provision(
-        input=input_pattern,
-        worktree_dir=tmp_path / 'ds1_worktree1',
-        on_failure='ignore',
-        result_renderer='disabled',
-    )
-    assert {(result['status'], result['state']) for result in results} == {
-        ('error', 'modified'),
-        ('error', 'untracked'),
-    }
-
-    # Check that a saved dataset can be provisioned
-    dataset.save()
-    dataset.provision(
-        input=input_pattern,
-        worktree_dir=tmp_path / 'ds1_worktree2',
-        result_renderer='disabled',
-    )
-
-
 @skip_if_on_windows
 def test_branch_deletion_after_provision(tmp_path):
     dataset = create_ds_hierarchy(tmp_path, 'ds1', 3)[0][2]


### PR DESCRIPTION
Fixes issue #69 

For unknown reasons, `Dataset.status` does not work properly in the context of a `git-annex-remake-datalad-remake` process if the origin dataset contains subdatasets.

