### PR TITLE
fix: perform proper provision in an annex remote

### DIFF
--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -390,7 +390,15 @@ def install_subdataset(
             absolute_path.as_uri(),
         ]
         call_git_lines(args)
-    worktree.get(str(subdataset_path), get_data=False, result_renderer='disabled')
+    stored_environ = dict(os.environ)
+    try:
+        for key in ('GIT_DIR', 'GIT_WORK_TREE'):
+            if key in os.environ:
+                del os.environ[key]
+        worktree.get(str(subdataset_path), get_data=False, result_renderer='disabled')
+    finally:
+        os.environ.clear()
+        os.environ.update(stored_environ)
     uninstalled_subdatasets.remove(subdataset_path)
     uninstalled_subdatasets.update(get_uninstalled_subdatasets(worktree))
 

--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -41,6 +41,7 @@ from datalad_next.runners import call_git_lines, call_git_success
 from datalad_remake.commands.make_cmd import read_list
 from datalad_remake.utils.chdir import chdir
 from datalad_remake.utils.glob import glob
+from datalad_remake.utils.patched_env import patched_env
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
@@ -390,15 +391,8 @@ def install_subdataset(
             absolute_path.as_uri(),
         ]
         call_git_lines(args)
-    stored_environ = dict(os.environ)
-    try:
-        for key in ('GIT_DIR', 'GIT_WORK_TREE'):
-            if key in os.environ:
-                del os.environ[key]
+    with patched_env(remove=['GIT_DIR', 'GIT_WORK_TREE']):
         worktree.get(str(subdataset_path), get_data=False, result_renderer='disabled')
-    finally:
-        os.environ.clear()
-        os.environ.update(stored_environ)
     uninstalled_subdatasets.remove(subdataset_path)
     uninstalled_subdatasets.update(get_uninstalled_subdatasets(worktree))
 

--- a/datalad_remake/utils/patched_env.py
+++ b/datalad_remake/utils/patched_env.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def patched_env(
+    add: dict | None = None,
+    remove: list[str] | None = None,
+):
+    """
+    Patch the environment for the duration of the context manager.
+
+    Parameters
+    ----------
+    add : dict
+        The environment variables to add.
+    remove : list[str]
+        The environment variables to remove.
+
+    Yields
+    -------
+    None
+    """
+    import os
+
+    # Store the original environment
+    original_env = dict(os.environ)
+
+    # Update the environment
+    os.environ.update(add or {})
+    for var in remove or []:
+        if var in os.environ:
+            del os.environ[var]
+
+    try:
+        yield
+    finally:
+        # Restore the original environment
+        os.environ.clear()
+        os.environ.update(original_env)


### PR DESCRIPTION
Fixes #69
Fixes #78

This PR fixes an issue where subdataset provision did not work if `provision` was invoked from an annex special remote-process.

The reason for the error was that the special remote sets the environment variables `GIT_DIR` and
`GIT_WORK_TREE`, which lead to problems in
`datalad.get`.