### PR TITLE
fix: update datalad-url for submodules as well

### DIFF
--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -381,13 +381,25 @@ def install_subdataset(
     if local_subdataset:
         absolute_path, parent_ds_path, path_from_root = local_subdataset[0]
         # Set the URL to the full source path
+        submodule_name = str(path_from_root.relative_to(parent_ds_path))
         args = [
             '-C',
             str(worktree.pathobj / parent_ds_path),
             'submodule',
             'set-url',
             '--',
-            str(path_from_root.relative_to(parent_ds_path)),
+            submodule_name,
+            absolute_path.as_uri(),
+        ]
+        call_git_lines(args)
+        args = [
+            '-C',
+            str(worktree.pathobj / parent_ds_path),
+            'config',
+            '-f',
+            '.gitmodules',
+            '--replace-all',
+            f'submodule.{submodule_name}.datalad-url',
             absolute_path.as_uri(),
         ]
         call_git_lines(args)

--- a/datalad_remake/commands/tests/create_datasets.py
+++ b/datalad_remake/commands/tests/create_datasets.py
@@ -49,6 +49,11 @@ def create_ds_hierarchy(
 
     root_dataset.get(recursive=True, result_renderer='disabled')
 
+    # Modify subdatasets that are installed in the root dataset
+    if subdataset_levels > 0:
+        (root_dataset.pathobj / f'{name}_subds0' / 'm0.txt').write_text('m0\n')
+        root_dataset.save(recursive=True, result_renderer='disabled')
+
     # Add datalad-remake remotes to the root dataset and all subdatasets
     add_remake_remote(root_dataset.path)
     subdataset_path = Path()

--- a/datalad_remake/commands/tests/test_provision.py
+++ b/datalad_remake/commands/tests/test_provision.py
@@ -21,6 +21,7 @@ file_path_templates = [
     '{{ds_name}}_subds0/{file}0.txt',
     '{{ds_name}}_subds0/{{ds_name}}_subds1/{file}1.txt',
     '{{ds_name}}_subds0/{{ds_name}}_subds1/{{ds_name}}_subds2/{file}2.txt',
+    '{{ds_name}}_subds0/m0.txt',
 ]
 
 


### PR DESCRIPTION
This PR changes the code so that the `datalad-url` property for submodules is also modified when provisioning a dataset. This fixes faulty provisioning in certain circumstances, i.e. when the locally installed subdataset had commits that were not present in its origin.

The PR contains a regression test.