### PR TITLE
fix: use OS-independent `PatternPath` for items

### DIFF
--- a/datalad_remake/__init__.py
+++ b/datalad_remake/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath as PatternPath
+
 from datalad_remake._version import __version__
 
 __all__ = [
@@ -14,6 +16,7 @@ __all__ = [
     'template_dir',
     'trusted_keys_config_key',
     'url_scheme',
+    'PatternPath',
 ]
 
 

--- a/datalad_remake/annexremotes/remake_remote.py
+++ b/datalad_remake/annexremotes/remake_remote.py
@@ -27,8 +27,8 @@ from datalad_next.annexremotes import SpecialRemote, super_main
 from datalad_next.datasets import Dataset
 from datalad_next.runners import call_git_success
 
-from datalad_remake import PatternPath
 from datalad_remake import (
+    PatternPath,
     priority_config_key,
     specification_dir,
     template_dir,
@@ -192,13 +192,12 @@ class RemakeRemote(SpecialRemote):
             compute_info['root_version'],
             compute_info['input'],
         ) as worktree:
-
             # Ensure that the method template is present, in case it is annexed.
             lgr.debug('Fetching method template')
             with patched_env(remove=['GIT_DIR', 'GIT_WORK_TREE']):
                 Dataset(worktree).get(
                     PatternPath(template_dir) / compute_info['method'],
-                    result_renderer='disabled'
+                    result_renderer='disabled',
                 )
 
             lgr.debug('Starting execution')

--- a/datalad_remake/annexremotes/tests/test_priority.py
+++ b/datalad_remake/annexremotes/tests/test_priority.py
@@ -4,6 +4,7 @@ from datalad_core.config import ConfigItem
 from datalad_next.tests import skip_if_on_windows
 
 from datalad_remake import (
+    PatternPath,
     allow_untrusted_execution_key,
     priority_config_key,
     specification_dir,
@@ -52,7 +53,7 @@ def test_compute_remote_priority(tmp_path, cfgman, monkeypatch, priority):
             build_json(
                 label,
                 [],
-                ['a.txt'],
+                [PatternPath('a.txt')],
                 {'content': f'{label}_parameter'},
             )
         )

--- a/datalad_remake/annexremotes/tests/test_remake_remote.py
+++ b/datalad_remake/annexremotes/tests/test_remake_remote.py
@@ -6,6 +6,7 @@ from datalad_remake import allow_untrusted_execution_key
 from datalad_remake.commands.tests.create_datasets import create_ds_hierarchy
 
 from ... import (
+    PatternPath,
     specification_dir,
     template_dir,
     trusted_keys_config_key,
@@ -53,7 +54,7 @@ def test_compute_remote_main(tmp_path, cfgman, monkeypatch, trusted):
     spec_name = '000001111122222'
     specification_path.mkdir(parents=True, exist_ok=True)
     (specification_path / spec_name).write_text(
-        build_json('echo', [], ['a.txt'], {'content': 'some_string'})
+        build_json('echo', [], [PatternPath('a.txt')], {'content': 'some_string'})
     )
     dataset.save()
 

--- a/datalad_remake/commands/make_cmd.py
+++ b/datalad_remake/commands/make_cmd.py
@@ -229,12 +229,8 @@ class Make(ValidatedInterface):
     ) -> Generator:
         ds: Dataset = dataset.ds if dataset else Dataset('.')
 
-        input_pattern = list(
-            map(PatternPath, (input or []) + read_list(input_list))
-        )
-        output_pattern = list(
-            map(PatternPath, (output or []) + read_list(output_list))
-        )
+        input_pattern = list(map(PatternPath, (input or []) + read_list(input_list)))
+        output_pattern = list(map(PatternPath, (output or []) + read_list(output_list)))
         parameter = (parameter or []) + read_list(parameter_list)
 
         parameter_dict = dict([p.split('=', 1) for p in parameter])
@@ -363,7 +359,9 @@ def add_url(
     *,
     url_only: bool,
 ) -> str:
-    lgr.debug('add_url: %s %s %s %s', str(dataset), str(file_path), url_base, repr(url_only))
+    lgr.debug(
+        'add_url: %s %s %s %s', str(dataset), str(file_path), url_base, repr(url_only)
+    )
 
     # Build the file-specific URL and store it in the annex
     url = url_base + f'&this={quote(str(file_path))}'
@@ -513,7 +511,9 @@ def install_containing_subdatasets(
     subdataset_infos = {
         # Determine the relative path of the parent dataset with system `Path`
         # instances, and convert it into `PatternPath` objects.
-        PatternPath(Path(result['path']).relative_to(Path(result['parentds']))): result['state']
+        PatternPath(Path(result['path']).relative_to(Path(result['parentds']))): result[
+            'state'
+        ]
         == 'present'
         for result in dataset.subdatasets(recursive=True)
     }
@@ -534,8 +534,9 @@ def install_containing_subdatasets(
             dataset.install(path=str(path), result_renderer='disabled')
             # Update subdataset_info to get newly installed subdatasets.
             subdataset_infos = {
-                PatternPath(Path(result['path']).relative_to(Path(result['parentds']))): result['state']
-                == 'present'
+                PatternPath(
+                    Path(result['path']).relative_to(Path(result['parentds']))
+                ): result['state'] == 'present'
                 for result in dataset.subdatasets(recursive=True)
             }
 

--- a/datalad_remake/commands/make_cmd.py
+++ b/datalad_remake/commands/make_cmd.py
@@ -36,14 +36,17 @@ from datalad_next.runners import (
 )
 
 from datalad_remake import (
+    PatternPath,
     specification_dir,
     template_dir,
     url_scheme,
 )
+from datalad_remake.commands import provision_cmd
 from datalad_remake.utils.chdir import chdir
 from datalad_remake.utils.compute import compute
 from datalad_remake.utils.getconfig import get_trusted_keys
 from datalad_remake.utils.glob import resolve_patterns
+from datalad_remake.utils.read_list import read_list
 from datalad_remake.utils.remake_remote import add_remake_remote
 from datalad_remake.utils.verify import verify_file
 
@@ -226,8 +229,12 @@ class Make(ValidatedInterface):
     ) -> Generator:
         ds: Dataset = dataset.ds if dataset else Dataset('.')
 
-        input_pattern = (input or []) + read_list(input_list)
-        output_pattern = (output or []) + read_list(output_list)
+        input_pattern = list(
+            map(PatternPath, (input or []) + read_list(input_list))
+        )
+        output_pattern = list(
+            map(PatternPath, (output or []) + read_list(output_list))
+        )
         parameter = (parameter or []) + read_list(parameter_list)
 
         parameter_dict = dict([p.split('=', 1) for p in parameter])
@@ -278,27 +285,13 @@ class Make(ValidatedInterface):
             )
 
 
-def read_list(list_file: str | Path | None) -> list[str]:
-    if list_file is None:
-        return []
-    return list(
-        filter(
-            lambda s: s != '' and not s.startswith('#'),
-            [
-                line.strip()
-                for line in Path(list_file).read_text().splitlines(keepends=False)
-            ],
-        )
-    )
-
-
 def get_url(
     dataset: Dataset,
     branch: str | None,
     template_name: str,
     parameters: dict[str, str],
-    input_pattern: list[str],
-    output_pattern: list[str],
+    input_pattern: list[PatternPath],
+    output_pattern: list[PatternPath],
     label: str,
 ) -> tuple[str, str]:
     # If something goes wrong after the compute specification was saved,
@@ -321,8 +314,8 @@ def get_url(
 def write_spec(
     dataset: Dataset,
     method: str,
-    input_pattern: list[str],
-    output_pattern: list[str],
+    input_pattern: list[PatternPath],
+    output_pattern: list[PatternPath],
     parameters: dict[str, str],
 ) -> str:
     # create the specification and hash it
@@ -347,24 +340,33 @@ def write_spec(
 
 
 def build_json(
-    method: str, inputs: list[str], outputs: list[str], parameters: dict[str, str]
+    method: str,
+    inputs: list[PatternPath],
+    outputs: list[PatternPath],
+    parameters: dict[str, str],
 ) -> str:
     return json.dumps(
         {
             'method': method,
-            'input': sorted(inputs),
-            'output': sorted(outputs),
+            'input': sorted(map(str, inputs)),
+            'output': sorted(map(str, outputs)),
             'parameter': parameters,
         },
         sort_keys=True,
     )
 
 
-def add_url(dataset: Dataset, file_path: str, url_base: str, *, url_only: bool) -> str:
-    lgr.debug('add_url: %s %s %s %s', str(dataset), file_path, url_base, repr(url_only))
+def add_url(
+    dataset: Dataset,
+    file_path: PatternPath,
+    url_base: str,
+    *,
+    url_only: bool,
+) -> str:
+    lgr.debug('add_url: %s %s %s %s', str(dataset), str(file_path), url_base, repr(url_only))
 
     # Build the file-specific URL and store it in the annex
-    url = url_base + f'&this={quote(file_path)}'
+    url = url_base + f'&this={quote(str(file_path))}'
     dataset_path, path = get_file_dataset(dataset.pathobj / file_path)
 
     # If the file does not exist and speculative computation is requested, we
@@ -410,11 +412,15 @@ def get_file_dataset(file: Path) -> tuple[Path, Path]:
 def provide(
     dataset: Dataset,
     branch: str | None,
-    input_patterns: list[str],
+    input_patterns: list[PatternPath],
 ) -> Path:
     lgr.debug('provide: %s %s %s', dataset, branch, input_patterns)
-    result = dataset.provision(
-        input=input_patterns, branch=branch, result_renderer='disabled'
+    result = list(
+        provision_cmd.provide(
+            dataset=dataset,
+            input_patterns=input_patterns,
+            source_branch=branch,
+        )
     )
     return Path(result[0]['path'])
 
@@ -423,7 +429,7 @@ def provide(
 def provide_context(
     dataset: Dataset,
     branch: str | None,
-    input_patterns: list[str],
+    input_patterns: list[PatternPath],
 ) -> Generator:
     worktree = provide(dataset, branch=branch, input_patterns=input_patterns)
     try:
@@ -437,7 +443,7 @@ def execute(
     worktree: Path,
     template_name: str,
     parameter: dict[str, str],
-    output_pattern: list[str],
+    output_pattern: list[PatternPath],
     trusted_key_ids: list[str] | None,
 ) -> None:
     lgr.debug(
@@ -471,8 +477,8 @@ def execute(
 def collect(
     worktree: Path,
     dataset: Dataset,
-    output_pattern: Iterable[str],
-) -> set[str]:
+    output_pattern: Iterable[PatternPath],
+) -> set[PatternPath]:
     output = resolve_patterns(root_dir=worktree, patterns=output_pattern)
 
     # Ensure that all subdatasets that are touched by paths in `output` are
@@ -492,7 +498,10 @@ def collect(
     return output
 
 
-def install_containing_subdatasets(dataset: Dataset, files: Iterable[str]) -> None:
+def install_containing_subdatasets(
+    dataset: Dataset,
+    files: Iterable[PatternPath],
+) -> None:
     """Install all subdatasets that contain a file from `files`."""
 
     # Set the set of subdatasets to the set of subdatasets that are installed.
@@ -502,7 +511,9 @@ def install_containing_subdatasets(dataset: Dataset, files: Iterable[str]) -> No
 
     # Get the relative paths of all known subdatasets
     subdataset_infos = {
-        Path(result['path']).relative_to(Path(result['parentds'])): result['state']
+        # Determine the relative path of the parent dataset with system `Path`
+        # instances, and convert it into `PatternPath` objects.
+        PatternPath(Path(result['path']).relative_to(Path(result['parentds']))): result['state']
         == 'present'
         for result in dataset.subdatasets(recursive=True)
     }
@@ -512,8 +523,8 @@ def install_containing_subdatasets(dataset: Dataset, files: Iterable[str]) -> No
         {
             prefix
             for file in files
-            for prefix in Path(file).parents
-            if prefix != Path('.')
+            for prefix in file.parents
+            if prefix != PatternPath('.')
         },
         key=lambda p: p.parts.__len__(),
     )
@@ -523,15 +534,16 @@ def install_containing_subdatasets(dataset: Dataset, files: Iterable[str]) -> No
             dataset.install(path=str(path), result_renderer='disabled')
             # Update subdataset_info to get newly installed subdatasets.
             subdataset_infos = {
-                Path(result['path']).relative_to(Path(result['parentds'])): result[
-                    'state'
-                ]
+                PatternPath(Path(result['path']).relative_to(Path(result['parentds']))): result['state']
                 == 'present'
                 for result in dataset.subdatasets(recursive=True)
             }
 
 
-def initialize_remotes(dataset: Dataset, files: Iterable[str]) -> None:
+def initialize_remotes(
+    dataset: Dataset,
+    files: Iterable[PatternPath],
+) -> None:
     """Add a remake remote to all datasets that are touched by the files"""
 
     # Get the subdatasets that contain generated files
@@ -543,7 +555,10 @@ def initialize_remotes(dataset: Dataset, files: Iterable[str]) -> None:
         add_remake_remote(str(dataset_dir))
 
 
-def unlock_files(dataset: Dataset, files: Iterable[str]) -> None:
+def unlock_files(
+    dataset: Dataset,
+    files: Iterable[PatternPath],
+) -> None:
     """Use datalad to resolve subdatasets and unlock files in the dataset."""
     # TODO: for some reason `dataset unlock` does not operate in the
     #  context of `dataset.pathobj`, so we need to change the working
@@ -561,8 +576,13 @@ def unlock_files(dataset: Dataset, files: Iterable[str]) -> None:
                 dataset.unlock(file, result_renderer='disabled')
 
 
-def create_output_space(dataset: Dataset, files: Iterable[str]) -> None:
+def create_output_space(
+    dataset: Dataset,
+    files: Iterable[PatternPath],
+) -> None:
     """Get all files that are part of the output space."""
     for f in files:
         with contextlib.suppress(IncompleteResultsError):
-            dataset.get(f, result_renderer='disabled')
+            # Convert the `PatternPath` instance to a system path and pass its
+            # string representation to `Dataset.get()`.
+            dataset.get(str(Path(f)), result_renderer='disabled')

--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -211,9 +211,7 @@ def provide(
     ).absolute()
     resolved_worktree_dir.mkdir(parents=True, exist_ok=True)
 
-    lgr.debug(
-        'Provisioning dataset %s at %s', dataset, resolved_worktree_dir
-    )
+    lgr.debug('Provisioning dataset %s at %s', dataset, resolved_worktree_dir)
 
     # Create a worktree
     args = (

--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -7,6 +7,7 @@ are currently also provisioned.
 from __future__ import annotations
 
 import logging
+import platform
 import re
 from pathlib import Path
 from re import Match
@@ -17,7 +18,6 @@ from typing import (
     cast,
 )
 
-from datalad.utils import on_windows
 from datalad_next.commands import (
     EnsureCommandParameterization,
     Parameter,
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
 lgr = logging.getLogger('datalad.remake.provision_cmd')
 
 drive_letter_matcher = re.compile('^[A-Z]:')
+
+on_windows = platform.system().lower() == 'windows'
+
 
 # decoration auto-generates standard help
 @build_doc
@@ -529,8 +532,7 @@ def get_remote_url(dataset: Dataset) -> str:
 
 
 def is_file_url(url: str) -> bool:
-    if on_windows:
-        starts_with_drive_letter = drive_letter_matcher.match(url)
-    else:
-        starts_with_drive_letter = False
+    starts_with_drive_letter = (
+        drive_letter_matcher.match(url) is not None if on_windows else False
+    )
     return url.startswith(('/', './', '../')) or starts_with_drive_letter

--- a/datalad_remake/commands/tests/test_collection.py
+++ b/datalad_remake/commands/tests/test_collection.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 from datalad_next.tests import skip_if_on_windows
 
-from ..make_cmd import collect
+
+from ... import PatternPath
 from .create_datasets import create_ds_hierarchy
 from .test_provision import get_file_list
+from datalad_remake.commands.make_cmd import collect
 
 
 @skip_if_on_windows
@@ -25,7 +27,10 @@ def test_collect(tmp_path):
         dataset=dataset,
         output_pattern=['results/**'],
     )
-    assert result == {'results/sub-01/a.txt', 'results/sub-01/b.txt'}
+    assert result == {
+        PatternPath('results/sub-01/a.txt'),
+        PatternPath('results/sub-01/b.txt'),
+    }
     assert set(get_file_list(dataset.pathobj / 'results')) == {
         'sub-01/a.txt',
         'sub-01/b.txt',

--- a/datalad_remake/commands/tests/test_collection.py
+++ b/datalad_remake/commands/tests/test_collection.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 from datalad_next.tests import skip_if_on_windows
 
+from datalad_remake.commands.make_cmd import collect
 
 from ... import PatternPath
 from .create_datasets import create_ds_hierarchy
 from .test_provision import get_file_list
-from datalad_remake.commands.make_cmd import collect
 
 
 @skip_if_on_windows

--- a/datalad_remake/commands/tests/test_collection.py
+++ b/datalad_remake/commands/tests/test_collection.py
@@ -25,7 +25,7 @@ def test_collect(tmp_path):
     result = collect(
         worktree=Path(worktree[0]['path']),
         dataset=dataset,
-        output_pattern=['results/**'],
+        output_pattern=[PatternPath('results/**')],
     )
     assert result == {
         PatternPath('results/sub-01/a.txt'),

--- a/datalad_remake/commands/tests/test_listhandling.py
+++ b/datalad_remake/commands/tests/test_listhandling.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from hypothesis import given
 from hypothesis.strategies import lists, text
 
-from datalad_remake.commands.make_cmd import read_list
+from datalad_remake.utils.read_list import read_list
 
 
 def test_empty_list_reading():

--- a/datalad_remake/commands/tests/test_make.py
+++ b/datalad_remake/commands/tests/test_make.py
@@ -6,7 +6,10 @@ from datalad_next.datasets import Dataset
 from datalad_next.tests import skip_if_on_windows
 
 import datalad_remake.commands.make_cmd
-from datalad_remake import allow_untrusted_execution_key
+from datalad_remake import (
+    PatternPath,
+    allow_untrusted_execution_key,
+)
 from datalad_remake.commands.make_cmd import get_url
 from datalad_remake.commands.tests.create_datasets import (
     create_simple_computation_dataset,
@@ -78,8 +81,8 @@ def test_label_url(monkeypatch):
         branch=None,
         template_name=test_method,
         parameters={'name': 'Robert', 'file': 'a.txt'},
-        input_pattern=['a.txt'],
-        output_pattern=['b.txt'],
+        input_pattern=[PatternPath('a.txt')],
+        output_pattern=[PatternPath('b.txt')],
         label='label1',
     )
     parts = urlparse(url).query.split('&')

--- a/datalad_remake/commands/tests/test_provision.py
+++ b/datalad_remake/commands/tests/test_provision.py
@@ -126,7 +126,9 @@ def get_file_list(
 @skip_if_on_windows
 def test_provision_context(tmp_path):
     dataset = create_ds_hierarchy(tmp_path, 'ds1')[0][2]
-    with provide_context(dataset, branch=None, input_patterns=[PatternPath('**')]) as worktree:
+    with provide_context(
+        dataset, branch=None, input_patterns=[PatternPath('**')]
+    ) as worktree:
         files = set(get_file_list(worktree))
         assert files
     assert not worktree.exists()

--- a/datalad_remake/commands/tests/test_provision.py
+++ b/datalad_remake/commands/tests/test_provision.py
@@ -10,6 +10,7 @@ from datalad_next.tests import skip_if_on_windows
 
 from datalad_remake.utils.chdir import chdir
 
+from ... import PatternPath
 from ..make_cmd import provide_context
 from .create_datasets import create_ds_hierarchy
 
@@ -125,7 +126,7 @@ def get_file_list(
 @skip_if_on_windows
 def test_provision_context(tmp_path):
     dataset = create_ds_hierarchy(tmp_path, 'ds1')[0][2]
-    with provide_context(dataset, branch=None, input_patterns=['**']) as worktree:
+    with provide_context(dataset, branch=None, input_patterns=[PatternPath('**')]) as worktree:
         files = set(get_file_list(worktree))
         assert files
     assert not worktree.exists()
@@ -135,7 +136,7 @@ def test_provision_context(tmp_path):
 def test_branch_deletion_after_provision(tmp_path):
     dataset = create_ds_hierarchy(tmp_path, 'ds1', 3)[0][2]
     with provide_context(
-        dataset=dataset, branch=None, input_patterns=['a.txt']
+        dataset=dataset, branch=None, input_patterns=[PatternPath('a.txt')]
     ) as worktree:
         assert worktree.exists()
     assert not worktree.exists()

--- a/datalad_remake/utils/glob.py
+++ b/datalad_remake/utils/glob.py
@@ -6,6 +6,7 @@ from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from datalad_remake import PatternPath
 from datalad_remake.utils.chdir import chdir
 
 if TYPE_CHECKING:
@@ -13,14 +14,32 @@ if TYPE_CHECKING:
 
 
 # Resolve input file patterns in the original dataset
-def resolve_patterns(root_dir: str | Path, patterns: Iterable[str]) -> set[str]:
+def resolve_patterns(
+    root_dir: str | Path,
+    patterns: Iterable[PatternPath],
+    *,
+    recursive: bool = True,
+) -> set[PatternPath]:
     return set(
-        filter(
-            lambda p: not (Path(root_dir) / p).is_dir(),
-            chain.from_iterable(
-                glob(pattern, root_dir=str(root_dir), recursive=True)
-                for pattern in patterns
-            ),
+        map(
+            PatternPath,
+            filter(
+                # This expression works because a `PatternPath` instance can be
+                # safely appended to a system path via `/`. The result is a system
+                # path where the last parts are the parts of the `PatternPath`
+                # instance.
+                lambda p: not (Path(root_dir) / p).is_dir(),
+                chain.from_iterable(
+                    glob(
+                        # Convert `PatternPath` instance to a platform path and then
+                        # to a string, which is required by the `glob` function.
+                        str(Path(pattern)),
+                        root_dir=root_dir,
+                        recursive=recursive,
+                    )
+                    for pattern in patterns
+                ),
+            )
         )
     )
 

--- a/datalad_remake/utils/glob.py
+++ b/datalad_remake/utils/glob.py
@@ -39,7 +39,7 @@ def resolve_patterns(
                     )
                     for pattern in patterns
                 ),
-            )
+            ),
         )
     )
 

--- a/datalad_remake/utils/read_list.py
+++ b/datalad_remake/utils/read_list.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_list(list_file: str | Path | None) -> list[str]:
+    if list_file is None:
+        return []
+    return list(
+        filter(
+            lambda s: s != '' and not s.startswith('#'),
+            [
+                line.strip()
+                for line in Path(list_file).read_text().splitlines(keepends=False)
+            ],
+        )
+    )


### PR DESCRIPTION
This is a large PR that introduces the type `PatternPath` (an alias of `PurePosixPath`), which is used to address items within a dataset, i.e. subdatasets, directories, and files.

This should allow the code to work uniformly on platforms with non-Unix path conventions, i.e. Windows.
