### PR TITLE
rf: use a single `patched_env` in annex remote

### DIFF
--- a/datalad_remake/commands/provision_cmd.py
+++ b/datalad_remake/commands/provision_cmd.py
@@ -41,7 +41,6 @@ from datalad_next.runners import call_git_lines, call_git_success
 from datalad_remake import PatternPath
 from datalad_remake.utils.chdir import chdir
 from datalad_remake.utils.glob import glob
-from datalad_remake.utils.patched_env import patched_env
 from datalad_remake.utils.read_list import read_list
 
 if TYPE_CHECKING:
@@ -421,8 +420,7 @@ def install_subdataset(
             absolute_path.as_uri(),
         ]
         call_git_lines(args)
-    with patched_env(remove=['GIT_DIR', 'GIT_WORK_TREE']):
-        worktree.get(str(subdataset_path), get_data=False, result_renderer='disabled')
+    worktree.get(str(subdataset_path), get_data=False, result_renderer='disabled')
     uninstalled_subdatasets.remove(subdataset_path)
     uninstalled_subdatasets.update(get_uninstalled_subdatasets(worktree))
 


### PR DESCRIPTION
This PR restricts the use of `patched_env` to the annex remote. The complete "TRANSFER RETRIEVE" implementation is wrapped into a single `patched_env` context.

`patched_env` became necessary because datalad's `Dataset.get` will not work properly if the environment variables `GIT_DIR` and `GIT_WORK_TREE` are set.
