### PR TITLE
feat: add `stdout`-handling

### DIFF
--- a/datalad_remake/annexremotes/remake_remote.py
+++ b/datalad_remake/annexremotes/remake_remote.py
@@ -281,7 +281,9 @@ class RemakeRemote(SpecialRemote):
             if output == this:
                 continue
             is_annexed, dataset_path, file_path = self._is_annexed(dataset, output)
-            self.annex.debug(f'_collect: _is_annexd({output}): {is_annexed}, {dataset_path}, {file_path}')
+            self.annex.debug(
+                f'_collect: _is_annexd({output}): {is_annexed}, {dataset_path}, {file_path}'
+            )
             if is_annexed:
                 self.annex.debug(
                     f'_collect: reinject: {worktree / output} -> {dataset_path}:{file_path}'
@@ -312,13 +314,13 @@ class RemakeRemote(SpecialRemote):
         shutil.copyfile(worktree / this, this_destination)
 
     def _is_annexed(
-        self,
-        dataset: Dataset,
-        file_path: PatternPath
+        self, dataset: Dataset, file_path: PatternPath
     ) -> tuple[bool, Path, Path]:
         """Check whether file_path is annexed and return the dataset and intra dataset path"""
         dataset_path, in_dataset_path = get_file_dataset(dataset.pathobj / file_path)
-        self.annex.debug(f'_is_annexed: {dataset}:{file_path} --> dataset_path: {dataset_path}, in_dataset_path: {in_dataset_path}')
+        self.annex.debug(
+            f'_is_annexed: {dataset}:{file_path} --> dataset_path: {dataset_path}, in_dataset_path: {in_dataset_path}'
+        )
         result = call_git_lines(
             ['annex', 'whereis', str(in_dataset_path)],
             cwd=dataset_path,

--- a/datalad_remake/annexremotes/remake_remote.py
+++ b/datalad_remake/annexremotes/remake_remote.py
@@ -25,7 +25,10 @@ from datalad_core.config import (
 )
 from datalad_next.annexremotes import SpecialRemote, super_main
 from datalad_next.datasets import Dataset
-from datalad_next.runners import call_git_success
+from datalad_next.runners import (
+    call_git_lines,
+    call_git_success,
+)
 
 from datalad_remake import (
     PatternPath,
@@ -159,12 +162,15 @@ class RemakeRemote(SpecialRemote):
         method_path = dataset.pathobj / template_dir / spec['method']
         dataset.get(method_path, result_renderer='disabled')
 
+        stdout = spec.get('stdout', None)
+
         return {
             'root_version': root_version,
             'this': PatternPath(this),
             'method': Path(spec['method']),
             'input': [PatternPath(path) for path in spec['input']],
             'output': [PatternPath(path) for path in spec['output']],
+            'stdout': PatternPath(stdout) if stdout else None,
             'parameter': spec['parameter'],
         }, dataset
 
@@ -212,6 +218,7 @@ class RemakeRemote(SpecialRemote):
                     compute_info['method'],
                     compute_info['parameter'],
                     compute_info['output'],
+                    compute_info['stdout'],
                     trusted_key_ids,
                 )
 
@@ -221,6 +228,7 @@ class RemakeRemote(SpecialRemote):
                     worktree,
                     dataset,
                     compute_info['output'],
+                    compute_info['stdout'],
                     compute_info['this'],
                     file_name,
                 )
@@ -257,6 +265,7 @@ class RemakeRemote(SpecialRemote):
         worktree: Path,
         dataset: Dataset,
         output_patterns: Iterable[PatternPath],
+        stdout: PatternPath | None,
         this: PatternPath,
         this_destination: str,
     ) -> None:
@@ -268,14 +277,11 @@ class RemakeRemote(SpecialRemote):
         # Collect all output files that have been created while creating
         # `this` file.
         for output in outputs:
+            # Skip `this` file because it will be copied to the destination
             if output == this:
                 continue
-            dataset_path, file_path = get_file_dataset(dataset.pathobj / output)
-            is_annexed = call_git_success(
-                ['annex', 'whereis', str(file_path)],
-                cwd=dataset_path,
-                capture_output=True,
-            )
+            is_annexed, dataset_path, file_path = self._is_annexed(dataset, output)
+            self.annex.debug(f'_collect: _is_annexd({output}): {is_annexed}, {dataset_path}, {file_path}')
             if is_annexed:
                 self.annex.debug(
                     f'_collect: reinject: {worktree / output} -> {dataset_path}:{file_path}'
@@ -286,9 +292,39 @@ class RemakeRemote(SpecialRemote):
                     capture_output=True,
                 )
 
+        # Collect possible stdout
+        if stdout is not None:
+            is_annexed, dataset_path, file_path = self._is_annexed(dataset, stdout)
+            if is_annexed:
+                self.annex.debug(
+                    f'_collect: reinject: {worktree / stdout} -> {dataset_path}:{file_path}'
+                )
+                call_git_success(
+                    ['annex', 'reinject', str(worktree / stdout), str(file_path)],
+                    cwd=dataset_path,
+                    capture_output=True,
+                )
+            else:
+                shutil.copyfile(worktree / stdout, dataset.pathobj / stdout)
+
         # Collect `this` file. It has to be copied to the destination given
         # by git-annex. Git-annex will check its integrity.
         shutil.copyfile(worktree / this, this_destination)
+
+    def _is_annexed(
+        self,
+        dataset: Dataset,
+        file_path: PatternPath
+    ) -> tuple[bool, Path, Path]:
+        """Check whether file_path is annexed and return the dataset and intra dataset path"""
+        dataset_path, in_dataset_path = get_file_dataset(dataset.pathobj / file_path)
+        self.annex.debug(f'_is_annexed: {dataset}:{file_path} --> dataset_path: {dataset_path}, in_dataset_path: {in_dataset_path}')
+        result = call_git_lines(
+            ['annex', 'whereis', str(in_dataset_path)],
+            cwd=dataset_path,
+        )
+        self.annex.debug(f'_is_annexed: result {result}')
+        return result != [], dataset_path, in_dataset_path
 
     def _get_priorities(self) -> list[str]:
         """Get configured priorities

--- a/datalad_remake/annexremotes/tests/test_priority.py
+++ b/datalad_remake/annexremotes/tests/test_priority.py
@@ -59,6 +59,7 @@ def test_compute_remote_priority(tmp_path, cfgman, monkeypatch, priority):
                 label,
                 [],
                 [PatternPath('a.txt')],
+                None,
                 {'content': f'{label}_parameter'},
             )
         )

--- a/datalad_remake/annexremotes/tests/test_remake_remote.py
+++ b/datalad_remake/annexremotes/tests/test_remake_remote.py
@@ -62,7 +62,7 @@ def test_compute_remote_main(tmp_path, cfgman, monkeypatch, trusted):
     spec_name = '000001111122222'
     specification_path.mkdir(parents=True, exist_ok=True)
     (specification_path / spec_name).write_text(
-        build_json('echo', [], [PatternPath('a.txt')], {'content': 'some_string'})
+        build_json('echo', [], [PatternPath('a.txt')], None, {'content': 'some_string'})
     )
     dataset.save()
 

--- a/datalad_remake/commands/make_cmd.py
+++ b/datalad_remake/commands/make_cmd.py
@@ -249,10 +249,11 @@ class Make(ValidatedInterface):
 
         input_pattern = list(map(PatternPath, (input or []) + read_list(input_list)))
         output_pattern = list(map(PatternPath, (output or []) + read_list(output_list)))
-        parameter = (parameter or []) + read_list(parameter_list)
         stdout_path = None if stdout is None else PatternPath(stdout)
 
-        parameter_dict = dict([p.split('=', 1) for p in parameter])
+        parameter_dict = dict(
+            [p.split('=', 1) for p in (parameter or []) + read_list(parameter_list)]
+        )
 
         # We have to get the URL first, because saving the specification to
         # the dataset will change the version.

--- a/datalad_remake/commands/make_cmd.py
+++ b/datalad_remake/commands/make_cmd.py
@@ -137,7 +137,9 @@ class Make(ValidatedInterface):
             'file pattern support python globbing, globbing is performed by '
             'installing all possibly matching subdatasets and performing '
             'globbing in those, recursively. That means expressions like `**` '
-            'might pull in a huge number of datasets).',
+            'might pull in a huge number of datasets). Input file patterns '
+            'must be relative, they are dereferenced from the root of the '
+            'dataset.',
         ),
         'input_list': Parameter(
             args=(
@@ -159,7 +161,9 @@ class Make(ValidatedInterface):
             action='append',
             doc='An output file pattern (repeat for multiple outputs)'
             'file pattern support python globbing, output globbing is performed '
-            'in the worktree after the computation).',
+            'in the worktree after the computation). Output file patterns '
+            'must be relative, they are dereferenced from the root of the '
+            'dataset.',
         ),
         'output_list': Parameter(
             args=(
@@ -200,7 +204,11 @@ class Make(ValidatedInterface):
             ),
             default=None,
             doc='Name of a file that will receive `stdout` output from the '
-            'computation. If not given, `stdout` output will be discarded.',
+            'computation. If not given, `stdout` output will be discarded. '
+            'It is preferable to NOT add the `stdout` file to the dataset on '
+            'which the computation is performed. The reason is that `stdout` '
+            'output tends to differ between runs, for example due to time '
+            'stamps or other non-deterministic factors.',
         ),
         'allow_untrusted_execution': Parameter(
             args=('--allow-untrusted-execution',),

--- a/datalad_remake/commands/tests/test_collection.py
+++ b/datalad_remake/commands/tests/test_collection.py
@@ -18,17 +18,21 @@ def test_collect(tmp_path):
     result_dir.mkdir(parents=True)
     (result_dir / 'a.txt').write_text('content: a\n')
     (result_dir / 'b.txt').write_text('content: b\n')
+    (result_dir / 'stdout.txt').write_text('stdout\n')
 
     result = collect(
         worktree=Path(worktree[0]['path']),
         dataset=dataset,
         output_pattern=[PatternPath('results/**')],
+        stdout=PatternPath('results/sub-01/stdout.txt'),
     )
     assert result == {
         PatternPath('results/sub-01/a.txt'),
         PatternPath('results/sub-01/b.txt'),
+        PatternPath('results/sub-01/stdout.txt'),
     }
     assert set(get_file_list(dataset.pathobj / 'results')) == {
         Path('sub-01/a.txt'),
         Path('sub-01/b.txt'),
+        Path('sub-01/stdout.txt'),
     }

--- a/datalad_remake/commands/tests/test_make.py
+++ b/datalad_remake/commands/tests/test_make.py
@@ -87,6 +87,7 @@ def test_label_url(monkeypatch):
         parameters={'name': 'Robert', 'file': 'a.txt'},
         input_pattern=[PatternPath('a.txt')],
         output_pattern=[PatternPath('b.txt')],
+        stdout=None,
         label='label1',
     )
     parts = urlparse(url).query.split('&')

--- a/datalad_remake/utils/compute.py
+++ b/datalad_remake/utils/compute.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from io import BufferedWriter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -65,6 +66,7 @@ def compute(
     root_directory: Path,
     template_path: Path,
     compute_arguments: dict[str, str],
+    stdout: BufferedWriter,
 ) -> None:
     template = toml_load(template_path)
 
@@ -75,4 +77,4 @@ def compute(
 
     with chdir(root_directory):
         lgr.debug(f'compute: RUNNING: {substituted_command}')
-        subprocess.run(substituted_command, check=True)
+        subprocess.run(substituted_command, check=True, stdout=stdout)

--- a/datalad_remake/utils/compute.py
+++ b/datalad_remake/utils/compute.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import subprocess
-from io import BufferedWriter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -66,7 +65,7 @@ def compute(
     root_directory: Path,
     template_path: Path,
     compute_arguments: dict[str, str],
-    stdout: BufferedWriter,
+    stdout: Path | None,
 ) -> None:
     template = toml_load(template_path)
 
@@ -77,4 +76,8 @@ def compute(
 
     with chdir(root_directory):
         lgr.debug(f'compute: RUNNING: {substituted_command}')
-        subprocess.run(substituted_command, check=True, stdout=stdout)
+        subprocess.run(
+            substituted_command,
+            check=True,
+            stdout=stdout.open('wb') if stdout else subprocess.DEVNULL,
+        )


### PR DESCRIPTION
This PR fixes #82

By default it suppresses all output on `stdout` that is created when the commands in a template are executed. The output can be written to a file by specifying the `-s/--stdout` argument in `datalad make`.
