### PR TITLE
chore: make sure there are project.dependencies in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,6 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-# This section is required to allow the direct refernces to the `datalad_core`
-# in the dependencies section below and in
-# `tool.hatch.envs.hatch-test.extra_dependencies`. Remove the section
-# `tool.hatch.metadata` when `datalad_core` is available on PyPI.
-[tool.hatch.metadata]
-allow-direct-references = true
-
 dependencies = [
   "annexremote",
   "datalad",
@@ -58,6 +51,13 @@ dependencies = [
   "datasalad",
   "toml",
 ]
+
+# This section is required to allow the direct refernces to the `datalad_core`
+# in the project.dependencies section above and in
+# `tool.hatch.envs.hatch-test.extra_dependencies`. Remove the section
+# `tool.hatch.metadata` when `datalad_core` is available on PyPI.
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [project.urls]
 Homepage = "https://github.com/datalad/datalad-remake"


### PR DESCRIPTION
I started looking more closely into `pyproject.toml` to see what still needs to be done before release. Consider this WIP but also feel free to cherry-pick. I don't know myself how far should this PR take us. See commits for details.

Some loose ends:
- [ ] Maintainers is commented out - set or remove? (e.g. datalad-next only has authors)
- [ ] Project URLs will change if we are targeting datalad-hub for long-term maintainance
- [ ] Get rid of `requirements.devel` - either add as `project.optional-dependencies` or decide that `hatch run` is enough for all devel tasks
- [ ] Set `exclude` for build? Currently, the sdist includes e.g. `.appveyor.yml` and `.github` - which does not matter much, but is a couple of bytes nevertheless.
- [ ] It seems that all the `tool.hatch.envs` use `extra-dependencies` instead of `depoendencies`, but only `tool.hatch.envs.tests` has a `template` defined, and there is no `default`; it seems to work and datalad-next does it in the same way, but is there a reason to only define extra-dependencies and not dependencies? I understood that extra- is mostly for inheritance.

Ping #73 

Reference: https://hatch.pypa.io/1.13/config/metadata/