### PR TITLE
doc: add design docs

### DIFF
--- a/docs/design/basics.rst
+++ b/docs/design/basics.rst
@@ -1,5 +1,57 @@
 Basic principles
 ================
 
-.. todo::
-   Describe the overall design: operation in worktrees, provisioning, URL keys, prospective computation.
+Provide -- execute -- collect
+-----------------------------
+
+DataLad-remake (re)computes in three stages:
+
+- Provisioning: creates a temporary, partial copy of the dataset (worktree) to provide an isolated environment.
+  Uses `git-worktree <https://git-scm.com/docs/git-worktree>`_ (unless on Windows, where it clones the dataset instead).
+  Checks out the given commit, if specified. Gets all input files in the worktree. Installs subdatasets as needed.
+- Execution: runs the computation in the provisioned worktree.
+  Before running, gets and unlocks outputs which are already available; installs subdatasets as needed.
+- Collection: copies the output files from the provisioned worktree into the dataset (main worktree).
+  Ensures that subdatasets which may receive outputs are installed before copying, and saves recursively afterwards.
+
+Note: when a file is recomputed during ``datalad get``, remake uses
+the commit originally recorded by ``datalad make`` to provide the
+worktree.  This means that recompute will use the same versions of the
+input files as the original computation, even if the files got changed
+in the meantime.
+
+Recomputing during ``datalad get`` assumes that the process is
+reproducible (bit-by-bit) and will error if the file checksum is
+different.
+
+Because provisioning involves git worktree or clone, all Git-tracked
+files are automatically available in the provisioned worktree. Annexed
+files have to be declared as inputs, if they are to be provisioned.
+
+Storing compute instructions
+----------------------------
+
+DataLad-remake stores compute instructions (command template, data
+dependencies, etc.) in text files committed to the dataset. These
+files are in the same branch as the (re)computed files. By default,
+DataLad remake expects commits adding compute instructions to be
+signed. For more details, see :doc:`files` and
+:doc:`trusted-execution`.
+
+DataLad-remake also uses `git annex addurl
+<https://git-annex.branchable.com/git-annex-addurl/>`_ to associate
+``datalad-remake://`` URLs with computed files in order to link them
+to the compute instructions. This URLs are handled by the remake
+special remote. They contain: label of the compute template, Git
+commit which added the compute specification, and the name (hash) of
+the compute specification file.
+
+Prospective execution
+---------------------
+
+By default, ``datalad make`` runs a computation, stores the compute
+specification, and associates it with the output files. However, it is
+also possible to skip computation, and only register compute
+instructions for future use by ``datalad get`` (for example, for files
+already computed via different means). This behavior can be chosen
+using the ``--prospective-execution`` flag.

--- a/docs/design/related.rst
+++ b/docs/design/related.rst
@@ -4,11 +4,55 @@ Delineation from related solutions
 DataLad (re)run
 ---------------
 
-.. todo::
-   Describe how ``datalad make`` differs from ``datalad run`` / ``datalad rerun``.
+DataLad provides `run
+<https://docs.datalad.org/en/stable/generated/man/datalad-run.html>`_
+and `rerun
+<https://docs.datalad.org/en/stable/generated/man/datalad-rerun.html>`_
+commands which are similar to ``make`` in that they also (re)execute
+arbitrary commands and record their impact on a dataset. However,
+there are key differences:
+
+- While ``make`` can be used to compute a file for the first time,
+  there is no "remake" command. Instead, recomputation is done by the
+  remake special remote during ``get`` and therefore should behave no
+  different from file downloads typically performed by ``get``.
+- The remake special remote operates in a temporary worktree, set to
+  the commit recorded by ``datalad make``. ``rerun`` operates in the
+  dataset's main worktree and by default executes commands at HEAD
+  (starting point can be specified with ``rerun --onto``).
+- The goal of the remake special remote is to recompute the contents
+  of an annexed file, and it will produce an error if the file can not
+  be reproduced. ``rerun`` can be used to verify computational
+  reproducibility but also to re-run same code with different inputs,
+  so it creates a new commit if the outputs differ.
+- The specification of data dependencies and compute instructions is
+  different, with ``make`` using committed files and ``run`` using
+  commit messages.
 
 Git-annex compute special remote
 --------------------------------
 
-.. todo::
-   Describe how datalad-remake differs from git-annex's built-in compute special remote.
+Git-annex provides a built-in `compute special remote
+<https://git-annex.branchable.com/special_remotes/compute/>`_ (see
+also: `computing annexed files
+<https://git-annex.branchable.com/tips/computing_annexed_files/>`_). This
+is a parallel development to DataLad-remake, and as such there are key
+differences in both implementation and behavior:
+
+- Specification of compute instructions and file dependencies is
+  different. Git-annex expects a compute program to communicate inputs
+  and outputs using standard input / output. DataLad-remake expects a
+  configuration file with command parameterization (compute template)
+  and a list of input and output file patterns.
+- The storage of compute instructions is different; git-annex uses its
+  VURL backend for annex keys and stores additional information in the
+  git-annex branch (unlike DataLad-annex, it does not commit
+  additional files to the same branch as the computed files).
+- The trust model is different: while DataLad-remake relies on
+  GPG-signed commits, Git-annex compute relies on a list of allowed
+  compute programs
+- By default, git-annex does not assume that the computed file needs
+  to be bit-by-bit reproducible (it has the ``--reproducible`` option
+  to enforce computational reproducibility).
+- Git-annex does not operate on subdatasets (submodules), all inputs
+  need to be gettable from the given Git repository.


### PR DESCRIPTION
This adds a description of basic principles and delineation from related solution (DataLad run / rerun, git-annex compute).